### PR TITLE
Allow any number of nested subcommands

### DIFF
--- a/lib/commander/runner.rb
+++ b/lib/commander/runner.rb
@@ -333,9 +333,19 @@ module Commander
     ##
     # Limit commands to those which are subcommands of the one that is active
     def limit_commands_to_subcommands(command)
-      commands.reject! { |k, v|
-        (k.to_s == command.name) ? true : !k.to_s.start_with?("#{command.name} ")
-      }
+      commands.select! do |other_sym, _|
+        other = other_sym.to_s
+        # Do not match sub-sub commands (matches for a second space)
+        if /\A#{command.name}\s.*\s/.match?(other)
+          false
+        # Do match regular sub commands
+        elsif /\A#{command.name}\s/.match?(other)
+          true
+        # Do not match any other commands
+        else
+          false
+        end
+      end
     end
 
     ##

--- a/lib/commander/version.rb
+++ b/lib/commander/version.rb
@@ -1,3 +1,3 @@
 module Commander
-  VERSION = '1.1.0'.freeze
+  VERSION = '1.2.0-dev1'.freeze
 end

--- a/lib/commander/version.rb
+++ b/lib/commander/version.rb
@@ -1,3 +1,3 @@
 module Commander
-  VERSION = '1.2.0-dev1'.freeze
+  VERSION = '1.1.1'.freeze
 end


### PR DESCRIPTION
This is now required by `flight-metal`. It is a simple case of rejecting all commands that have a to following white space character after the command that has been executed. This indicates they are part of a deeper nesting.