### PR TITLE
Tweak the error handling for sub commands

### DIFF
--- a/lib/commander/command.rb
+++ b/lib/commander/command.rb
@@ -9,6 +9,8 @@ OptionParser.prepend Commander::Patches::ImplicitShortTags
 OptionParser.prepend Commander::Patches::DecimalInteger
 
 module Commander
+  class SubCommandGroupError < StandardError; end
+
   class Command
     prepend Patches::ValidateInputs
 
@@ -159,7 +161,7 @@ module Commander
     alias action when_called
 
     ##
-    # Handles displaying subcommand help. By default it will set the action to 
+    # Handles displaying subcommand help. By default it will set the action to
     # display the subcommand if the action hasn't already been set
 
     def sub_command_group?
@@ -168,11 +170,7 @@ module Commander
 
     def sub_command_group=(value)
       @sub_command_group = value
-      if @when_called.empty?
-        self.action {
-          exec("#{$0} #{ARGV.join(" ")} --help")
-        }
-      end
+      self.action { raise SubCommandGroupError } if value
     end
 
     def configure_sub_command(runner)

--- a/lib/commander/patches/validate_inputs.rb
+++ b/lib/commander/patches/validate_inputs.rb
@@ -27,7 +27,10 @@ module Commander
 
       def assert_correct_number_of_args!(args)
         return if primary_command_word == 'help'
-        if too_many_args?(args)
+        too_many = too_many_args?(args)
+        if too_many && sub_command_group?
+          raise CommandUsageError, "unrecognised command. Please select from the following:"
+        elsif too_many
           raise CommandUsageError, "excess arguments for command '#{primary_command_word}'"
         elsif too_few_args?(args)
           raise CommandUsageError, "insufficient arguments for command '#{primary_command_word}'"

--- a/lib/commander/runner.rb
+++ b/lib/commander/runner.rb
@@ -3,15 +3,21 @@ require 'paint'
 module Commander
   class Runner
     DEFAULT_ERROR_HANDLER = lambda do |runner, e|
-      $stderr.puts "#{Paint[runner.program(:name), '#2794d8']}: #{Paint[e.to_s, :red, :bright]}"
+      error_msg = "#{Paint[runner.program(:name), '#2794d8']}: #{Paint[e.to_s, :red, :bright]}"
       case e
       when OptionParser::InvalidOption,
            Commander::Runner::InvalidCommandError,
            Commander::Patches::CommandUsageError
-        $stderr.puts "\nUsage:\n\n"
         if cmd = runner.active_command
+          $stderr.puts error_msg
+          $stderr.puts "\nUsage:\n\n"
           runner.command('help').run(cmd.name)
+        elsif runner.args_without_command_name.empty?
+          $stderr.puts "Usage:\n\n"
+          runner.command('help').run(:error)
         else
+          $stderr.puts error_msg
+          $stderr.puts "\nUsage:\n\n"
           runner.command('help').run(:error)
         end
       end

--- a/lib/commander/runner.rb
+++ b/lib/commander/runner.rb
@@ -9,13 +9,10 @@ module Commander
            Commander::Runner::InvalidCommandError,
            Commander::Patches::CommandUsageError
         $stderr.puts "\nUsage:\n\n"
-        args = ARGV.reject{|o| o[0] == '-'}
-        if runner.command(topic = args[0..1].join(" "))
-          runner.command("help").run(topic)
-        elsif runner.command(args[0])
-          runner.command("help").run(args[0])
+        if cmd = runner.active_command
+          runner.command('help').run(cmd.name)
         else
-          runner.command("help").run(:error)
+          runner.command('help').run(:error)
         end
       end
       exit(1)

--- a/lib/commander/runner.rb
+++ b/lib/commander/runner.rb
@@ -8,18 +8,32 @@ module Commander
       when OptionParser::InvalidOption,
            Commander::Runner::InvalidCommandError,
            Commander::Patches::CommandUsageError
+        # Display the error message for a specific command. Most likely due to
+        # invalid command syntax
         if cmd = runner.active_command
           $stderr.puts error_msg
           $stderr.puts "\nUsage:\n\n"
           runner.command('help').run(cmd.name)
+        # Display the main app help text when called without `--help`
         elsif runner.args_without_command_name.empty?
           $stderr.puts "Usage:\n\n"
           runner.command('help').run(:error)
+        # Display the main app help text when called with arguments. Mostly
+        # likely an invalid syntax error
         else
           $stderr.puts error_msg
           $stderr.puts "\nUsage:\n\n"
           runner.command('help').run(:error)
         end
+      # Display the help text for sub command groups when called without `--help`
+      when SubCommandGroupError
+        if cmd = runner.active_command
+          $stderr.puts "Usage:\n\n"
+          runner.command('help').run(cmd.name)
+        end
+      # Catch all error message for all other issues
+      else
+        $stderr.puts error_msg
       end
       exit(1)
     end

--- a/lib/commander/version.rb
+++ b/lib/commander/version.rb
@@ -1,3 +1,3 @@
 module Commander
-  VERSION = '1.1.1'.freeze
+  VERSION = '1.1.2'.freeze
 end


### PR DESCRIPTION
This PR updates commanders error handling for sub commands. Previously it would always display the sub-sub commands parent's help text (which isn't particularly useful).

From now on, the error handling will display the help text for the currently active command. This should remove the possibility for the wrong command to be displayed.

Also the main help text handling has been updated so `--help` doesn't need to be pushed onto the `ARGV` array. It will automatically detect it has been called without arguments and respond accordingly.

And finally, the help text for sub commands is no longer generated using an `exec`. This speeds up the app and should reduce the exposure to bugs.