### PR TITLE
Allow subcommands to be sorted non alphabetically

### DIFF
--- a/lib/commander/command.rb
+++ b/lib/commander/command.rb
@@ -4,6 +4,7 @@ require 'commander/patches/decimal-integer'
 require 'commander/patches/validate_inputs'
 require 'commander/patches/option_defaults'
 require 'commander/patches/help_formatter_binding'
+require 'commander/patches/priority_sort'
 
 OptionParser.prepend Commander::Patches::ImplicitShortTags
 OptionParser.prepend Commander::Patches::DecimalInteger
@@ -13,6 +14,7 @@ module Commander
 
   class Command
     prepend Patches::ValidateInputs
+    prepend Patches::PrioritySort
 
     attr_accessor :name, :examples, :syntax, :description
     attr_accessor :summary, :proxy_options, :options, :hidden

--- a/lib/commander/help_formatters/terminal/subcommand_help.erb
+++ b/lib/commander/help_formatters/terminal/subcommand_help.erb
@@ -15,7 +15,7 @@
 
 
   <%= $terminal.color "SUBCOMMANDS", :bold %>:
-<% for name, command in @commands.sort -%>
+<% @commands.values.sort.map { |c| [c.name, c] }.each do |name, command| -%>
   <% unless alias? name %>
     <%= "%-#{max_command_length}s %s" % [command.name, command.summary || command.description] -%>
   <% end -%>

--- a/lib/commander/help_formatters/terminal_compact/subcommand_help.erb
+++ b/lib/commander/help_formatters/terminal_compact/subcommand_help.erb
@@ -8,7 +8,7 @@
   <%= cmd.description || cmd.summary %>
 <% end -%>
 
-<% for name, command in @commands.sort -%>
+<% @commands.values.sort.map { |c| [c.name, c] }.each do |name, command| -%>
 <% unless alias? name -%>
     <%= "%-#{max_command_length}s %s" % [command.name, command.summary || command.description] %>
 <% end -%>

--- a/lib/commander/patches/priority_sort.rb
+++ b/lib/commander/patches/priority_sort.rb
@@ -3,13 +3,18 @@
 module Commander
   module Patches
     module PrioritySort
+      attr_accessor :priority
+
       def <=>(other)
         # Different classes can not be compared and thus are considered
         # equal in priority
         return 0 unless self.class == other.class
 
-        # Delegate the sort based on the name
-        self.name <=> other.name
+        # Sort firstly based on the commands priority
+        comp = (self.priority || 0) <=> (other.priority || 0)
+
+        # Fall back on name comparison if priority is equal
+        comp == 0 ? self.name <=> other.name : comp
       end
     end
   end

--- a/lib/commander/patches/priority_sort.rb
+++ b/lib/commander/patches/priority_sort.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Commander
+  module Patches
+    module PrioritySort
+      def <=>(other)
+        # Different classes can not be compared and thus are considered
+        # equal in priority
+        return 0 unless self.class == other.class
+
+        # Delegate the sort based on the name
+        self.name <=> other.name
+      end
+    end
+  end
+end

--- a/lib/commander/version.rb
+++ b/lib/commander/version.rb
@@ -1,3 +1,3 @@
 module Commander
-  VERSION = '1.1.2'.freeze
+  VERSION = '1.2.0'.freeze
 end


### PR DESCRIPTION
This will allow the CRUD actions to appear first in the commands list