### PR TITLE
Fix remaining parsing issues

### DIFF
--- a/lib/commander/runner.rb
+++ b/lib/commander/runner.rb
@@ -71,7 +71,7 @@ module Commander
       remaining_args = global_parser.arguments
 
       # Parse the command slop options
-      if active_command?
+      if active_command? && !active_command.skip_option_parsing(false)
         local_parser = Slop::Parser.new(active_command.slop)
         local_opts = local_parser.parse(remaining_args)
         remaining_args = local_parser.arguments
@@ -201,7 +201,7 @@ module Commander
 
     def valid_command_names_from(*args)
       commands.keys.find_all do |name|
-        name if flagless_args_string =~ /^#{name}\b/
+        name if flagless_args_string =~ /^#{name}(?![[:graph:]])/
       end
     end
 

--- a/lib/commander/version.rb
+++ b/lib/commander/version.rb
@@ -1,3 +1,3 @@
 module Commander
-  VERSION = '2.1.0'.freeze
+  VERSION = '2.1.1'.freeze
 end


### PR DESCRIPTION
The parsing of command flags can be skipped on a per command basis
This is useful as a catch all command.

Also positional arguments where not parsing correctly if a command
was a prefix to another:

```
list
list-groups

parse(list-group) => list
```

This leads to various weird help texts and has been disabled