### PR TITLE
Fix help formatting bugs and fully document Slop

### DIFF
--- a/lib/commander/command.rb
+++ b/lib/commander/command.rb
@@ -104,15 +104,6 @@ module Commander
     alias action when_called
 
     ##
-    # Causes the option parsing to be skipped. The flags will be passed
-    # down within the args instead
-    #
-
-    def skip_option_parsing(set = true)
-      @skip_option_parsing ||= set
-    end
-
-    ##
     # Flags the command not to appear in general help text
     #
 

--- a/lib/commander/error_handler.rb
+++ b/lib/commander/error_handler.rb
@@ -1,7 +1,7 @@
 module Commander
   ##
   # Internal error class to delay rendering help text
-  # This is required as the help command pints directly to stdout
+  # This is required as the help command points directly to stdout
   # In general this has a bit of a code smell to it, and should
   # not be used publicly
   class InternalCallableError < StandardError

--- a/lib/commander/help_formatters/terminal/command_help.erb
+++ b/lib/commander/help_formatters/terminal/command_help.erb
@@ -27,13 +27,15 @@
   <%= $terminal.color "OPTIONS", :bold %>:
 	<% slop.options.each do |option| -%>
 
-  <% tag = if [Slop::BoolOption, Slop::NullOption].include?(option.class)
-             nil
-           else
-             option.key.upcase
-           end
-  -%>
-  <%= option.flags.join ', ' %> <%= tag %>
+<% tag = if [Slop::BoolOption, Slop::NullOption].include?(option.class)
+           nil
+         elsif meta = option.config[:meta]
+           meta
+         else
+           option.key.upcase
+         end
+-%>
+    <%= option.flags.join ', ' %> <%= tag %>
         <%= Commander::HelpFormatter.indent 8, option.desc %><% if option.default_value %>
         <%= $terminal.color "Default", :bold %>: <%= option.default_value %><% end %>
   <% end -%>

--- a/lib/commander/help_formatters/terminal/help.erb
+++ b/lib/commander/help_formatters/terminal/help.erb
@@ -34,6 +34,8 @@
 
 <% tag = if [Slop::BoolOption, Slop::NullOption]
            nil
+         elsif meta = option.config[:meta]
+           meta
          else
            option.key.upcase
          end

--- a/lib/commander/help_formatters/terminal/help.erb
+++ b/lib/commander/help_formatters/terminal/help.erb
@@ -32,12 +32,12 @@
   <%= $terminal.color "GLOBAL OPTIONS", :bold %>:
 	<% global_slop.options.each do |global| -%>
 
-    <% tag = if [Slop::BoolOption, Slop::NullOption]
-               nil
-             else
-               option.key.upcase
-             end
-    -%>
+<% tag = if [Slop::BoolOption, Slop::NullOption]
+           nil
+         else
+           option.key.upcase
+         end
+-%>
     <%= global.flags.join ', ' %> <%= tag %>
         <%= global.desc %>
 	<% end -%>

--- a/lib/commander/help_formatters/terminal/help.erb
+++ b/lib/commander/help_formatters/terminal/help.erb
@@ -41,7 +41,7 @@
          end
 -%>
     <%= global.flags.join ', ' %> <%= tag %>
-        <%= global.desc %>
+        <%= Commander::HelpFormatter.indent 8, global.desc %>
 	<% end -%>
 <% end -%>
 <% if program :help -%>

--- a/lib/commander/version.rb
+++ b/lib/commander/version.rb
@@ -1,3 +1,3 @@
 module Commander
-  VERSION = '2.1.1'.freeze
+  VERSION = '2.1.2'.freeze
 end


### PR DESCRIPTION
Fixes a couple of formatting bugs in the help text and documents `slop` in the README. Also combined the `slop` parser's into a single object. This is to resolve double parsing bugs