### PR TITLE
Create an ErrorHandler object to prettify the error messages

### DIFF
--- a/lib/commander/cli.rb
+++ b/lib/commander/cli.rb
@@ -5,8 +5,8 @@ module Commander
     ##
     # Wrapper run command with error handling
     def run!(*args)
-      Commander.traceable_error_handler(*args) do |new_args|
-        run(*new_args)
+      Commander::ErrorHandler.new(program(:name)).start do |handler|
+        run(*handler.parse_trace(*args))
       end
     end
 

--- a/lib/commander/error_handler.rb
+++ b/lib/commander/error_handler.rb
@@ -17,8 +17,6 @@ module Commander
     end
   end
 
-  INTERRUPT_MSG = 'Received Interrupt!'
-
   def self.traceable_error_handler(*args)
     # Determines if there is a --trace flag before a --
     trace_index = args.index do |a|
@@ -39,16 +37,11 @@ module Commander
     error_handler(!!trace_index) do
       yield(new_args) if block_given?
     end
-
-  rescue Interrupt
-    # Start Rescuing Interrupt Immediately
-    $stderr.puts INTERRUPT_MSG
-    exit 130
   end
 
   def self.error_handler(trace = false)
     yield if block_given?
-  rescue StandardError, Interrupt => e
+  rescue StandardError => e
     $stderr.puts e.full_message if trace
 
     error_msg = e.message
@@ -59,10 +52,6 @@ module Commander
       exit_code = 126
       $stderr.puts error_msg
       e.call
-    when Interrupt
-      $stderr.puts INTERRUPT_MSG
-      # See: https://shapeshed.com/unix-exit-codes/
-      exit_code = 130
     else
       $stderr.puts error_msg
     end

--- a/lib/commander/runner.rb
+++ b/lib/commander/runner.rb
@@ -1,4 +1,3 @@
-require 'paint'
 require 'ostruct'
 
 module Commander
@@ -91,18 +90,16 @@ module Commander
         # Return generic help
         run_help_command('')
       end
-    rescue => e
-      msg = "#{Paint[program(:name), '#2794d8']}: #{Paint[e.to_s, :red, :bright]}"
-      new_error = e.exception(msg)
-
-      if INBUILT_ERRORS.include?(new_error.class)
-        new_error = InternalCallableError.new(e.message) do
+    rescue => original
+      error = original
+      if INBUILT_ERRORS.include?(error.class)
+        error = InternalCallableError.new(error.message) do
           $stderr.puts "\nUsage:\n\n"
           name = active_command? ? active_command.name : :error
           run_help_command([name])
         end
       end
-      raise new_error
+      raise error
     end
 
     ##

--- a/lib/commander/version.rb
+++ b/lib/commander/version.rb
@@ -1,3 +1,3 @@
 module Commander
-  VERSION = '2.1.2'.freeze
+  VERSION = '2.2.0'.freeze
 end


### PR DESCRIPTION
Version 1 of `Commander` use to prettify the error outputs. This would include:
* The program name, and
* Colourise the error.

This was last in the upgrade to `Commander` version . Likely due to the error handling error being overhauled. It has now been implemented via a `ErrorHandler` struct which is also responsible for `--trace` support.

The `Interrupt` error handling has been removed as its a bit half-baked. Commander can not start it early enough for it to be useful. The standard design pattern is to include interrupt/signal handling in the `bin` files.

The version has been bumped to `2.2.0` as this change is a bit more than a bug fix