### PR TITLE
WIP: Command groups

### DIFF
--- a/lib/commander.rb
+++ b/lib/commander.rb
@@ -27,6 +27,7 @@ $terminal = HighLine.new
 require 'commander/error_handler'
 require 'commander/version'
 require 'commander/command'
+require 'commander/group'
 require 'commander/runner'
 require 'commander/help_formatters'
 require 'commander/cli'

--- a/lib/commander/cli.rb
+++ b/lib/commander/cli.rb
@@ -82,6 +82,10 @@ module Commander
       @commands ||= {}
     end
 
+    def groups
+      @groups ||= {}
+    end
+
     ##
     # Hash of Global Options
     #
@@ -99,6 +103,13 @@ module Commander
       name = name.to_s
       (commands[name] ||= Command.new(name)).tap do |cmd|
         yield cmd if block_given?
+      end
+    end
+
+    def group(name)
+      name = name.to_s
+      (groups[name] ||= Group.new(name)).tap do |grp|
+        yield grp if block_given?
       end
     end
 

--- a/lib/commander/cli.rb
+++ b/lib/commander/cli.rb
@@ -77,11 +77,13 @@ module Commander
 
 
     ##
-    # Hash of Command objects
+    # Hash of ungrouped Command objects
     def commands
       @commands ||= {}
     end
 
+    ##
+    # Hash of Group objects
     def groups
       @groups ||= {}
     end
@@ -108,6 +110,7 @@ module Commander
 
     def group(name)
       name = name.to_s
+
       (groups[name] ||= Group.new(name)).tap do |grp|
         yield grp if block_given?
       end

--- a/lib/commander/cli.rb
+++ b/lib/commander/cli.rb
@@ -12,7 +12,7 @@ module Commander
 
     def run(*args)
       instance = Runner.new(
-        @program, commands, default_command,
+        @program, commands, default_command, groups,
         global_slop, aliases, args
       )
       instance.run

--- a/lib/commander/command.rb
+++ b/lib/commander/command.rb
@@ -10,10 +10,10 @@ module Commander
     ##
     # Initialize new command with specified _name_.
 
-    def initialize(name, group: nil)
+    def initialize(name)
       @name, @examples, @when_called = name.to_s, [], []
       @options = []
-      @group = group
+      @group = nil
     end
 
     # Allows the commands to be sorted via priority

--- a/lib/commander/command.rb
+++ b/lib/commander/command.rb
@@ -10,10 +10,10 @@ module Commander
     ##
     # Initialize new command with specified _name_.
 
-    def initialize(name)
+    def initialize(name, group=nil)
       @name, @examples, @when_called = name.to_s, [], []
       @options = []
-      @group = nil
+      @group = group
     end
 
     # Allows the commands to be sorted via priority

--- a/lib/commander/command.rb
+++ b/lib/commander/command.rb
@@ -5,14 +5,15 @@ module Commander
     class CommandUsageError < StandardError; end
 
     attr_accessor :name, :examples, :syntax, :description, :priority
-    attr_accessor :summary, :options
+    attr_accessor :summary, :options, :group
 
     ##
     # Initialize new command with specified _name_.
 
-    def initialize(name)
+    def initialize(name, group: nil)
       @name, @examples, @when_called = name.to_s, [], []
       @options = []
+      @group = group
     end
 
     # Allows the commands to be sorted via priority

--- a/lib/commander/group.rb
+++ b/lib/commander/group.rb
@@ -1,0 +1,11 @@
+module Commander
+  class Group
+
+    attr_accessor :name, :description
+
+    def initialize(name, group: nil)
+      @name = name.to_s
+      @description = ""
+    end
+  end
+end

--- a/lib/commander/group.rb
+++ b/lib/commander/group.rb
@@ -3,9 +3,20 @@ module Commander
 
     attr_accessor :name, :description
 
-    def initialize(name, group: nil)
+    def initialize(name)
       @name = name.to_s
       @description = ""
+    end
+
+    def commands
+      @commands ||= {}
+    end
+
+    def command(name)
+      name = name.to_s
+      (commands[name] ||= Command.new(name)).tap do |cmd|
+        yield cmd if block_given?
+      end
     end
   end
 end

--- a/lib/commander/group.rb
+++ b/lib/commander/group.rb
@@ -1,11 +1,10 @@
 module Commander
   class Group
 
-    attr_accessor :name, :description
+    attr_accessor :name, :summary, :description
 
     def initialize(name)
       @name = name.to_s
-      @description = ""
     end
 
     def commands

--- a/lib/commander/group.rb
+++ b/lib/commander/group.rb
@@ -1,7 +1,7 @@
 module Commander
   class Group
 
-    attr_accessor :name, :summary, :description
+    attr_accessor :name, :summary, :description, :syntax
 
     def initialize(name)
       @name = name.to_s
@@ -13,7 +13,7 @@ module Commander
 
     def command(name)
       name = name.to_s
-      (commands[name] ||= Command.new(name)).tap do |cmd|
+      (commands[name] ||= Command.new(name, self)).tap do |cmd|
         yield cmd if block_given?
       end
     end

--- a/lib/commander/help_formatters.rb
+++ b/lib/commander/help_formatters.rb
@@ -39,6 +39,21 @@ module Commander
       end
     end
 
+    class GroupContext < Context
+      def decorate_binding(bind)
+        bind.eval("max_command_length = #{max_command_length(bind)}")
+      end
+
+      def max_command_length(bind)
+        max_key_length(bind.eval('@commands'))
+      end
+
+      def max_key_length(hash, default = 20)
+        longest = hash.keys.max_by(&:size)
+        longest ? longest.size : default
+      end
+    end
+
     module_function
 
     def indent(amount, text)

--- a/lib/commander/help_formatters/base.rb
+++ b/lib/commander/help_formatters/base.rb
@@ -19,6 +19,10 @@ module Commander
       def render_command(command)
         "Implement help for #{command.name} here"
       end
+
+      def render_group(group)
+        "Implement help for #{group.name} here"
+      end
     end
   end
 end

--- a/lib/commander/help_formatters/terminal.rb
+++ b/lib/commander/help_formatters/terminal.rb
@@ -11,6 +11,10 @@ module Commander
         template(:command_help).result(Context.new(command).get_binding)
       end
 
+      def render_group(group)
+        template(:group_help).result(GroupContext.new(group).get_binding)
+      end
+
       def template(name)
         ERB.new(File.read(File.join(File.dirname(__FILE__), 'terminal', "#{name}.erb")), nil, '-')
       end

--- a/lib/commander/help_formatters/terminal/group_help.erb
+++ b/lib/commander/help_formatters/terminal/group_help.erb
@@ -1,0 +1,22 @@
+<% if !@syntax -%>
+  <%= $terminal.color "COMMAND", :bold %>:
+
+    <%= @name %>
+<% else -%>
+  <%= $terminal.color "SYNOPSIS", :bold %>:
+
+    <%= syntax -%>
+
+<% end -%>
+
+  <%= $terminal.color "DESCRIPTION", :bold %>:
+
+    <%= Commander::HelpFormatter.indent 4, (@description || @summary || 'No description.') -%>
+
+
+  <%= $terminal.color "SUBCOMMANDS", :bold %>:
+<% for name, command in @commands.sort -%>
+
+    <%= "%-#{max_command_length}s %s" % [command.name, command.summary || command.description] -%>
+<% end %>
+

--- a/lib/commander/help_formatters/terminal/help.erb
+++ b/lib/commander/help_formatters/terminal/help.erb
@@ -17,9 +17,9 @@
     <%= Commander::HelpFormatter.indent 4, program(:description) %>
 
   <%= $terminal.color "COMMANDS", :bold %>:
-<% for name, command in @help_commands.sort -%>
+<% for name, obj in @help_commands.sort -%>
 	<% unless alias? name %>
-    <%= "%-#{max_command_length}s %s" % [command.name, command.summary || command.description] -%>
+    <%= "%-#{max_command_length}s %s" % [obj.name, obj.summary || obj.description] -%>
 	<% end -%>
 <% end %>
 <% unless @aliases.empty? %>

--- a/lib/commander/runner.rb
+++ b/lib/commander/runner.rb
@@ -87,6 +87,9 @@ module Commander
       elsif opts.help && active_command?
         # Return help for the active_command
         run_help_command([active_command!.name])
+      elsif active_group?
+        # Return command listing for active_group
+        raise active_group.to_s
       elsif active_command?
         # Run the active_command
         active_command.run!(remaining_args, opts, config)
@@ -139,6 +142,10 @@ module Commander
       @commands[name.to_s]
     end
 
+    def group(name)
+      @groups[name.to_s]
+    end
+
     ##
     # Check if command _name_ is an alias.
 
@@ -179,6 +186,24 @@ module Commander
 
     def default_command?
       default_command ? true : false
+    end
+
+    def active_group
+      @__active_group ||= group(group_name_from_args)
+    end
+
+    def group_name_from_args
+      @__command_name_from_args ||= valid_group_names_from(*@args.dup).sort.last
+    end
+
+    def valid_group_names_from(*args)
+      groups.keys.find_all do |name|
+        name if flagless_args_string =~ /^#{name}(?![[:graph:]])/
+      end
+    end
+
+    def active_group?
+      active_group ? true : false
     end
 
     ##

--- a/lib/commander/runner.rb
+++ b/lib/commander/runner.rb
@@ -89,7 +89,7 @@ module Commander
         run_help_command([active_command!.name])
       elsif active_group?
         # Return command listing for active_group
-        raise active_group.to_s
+        run_help_group(active_group.name)
       elsif active_command?
         # Run the active_command
         active_command.run!(remaining_args, opts, config)
@@ -188,6 +188,10 @@ module Commander
       default_command ? true : false
     end
 
+    def active_group!
+      active_group.tap { |g| require_valid_group(g) }
+    end
+
     def active_group
       @__active_group ||= group(group_name_from_args)
     end
@@ -277,6 +281,12 @@ module Commander
         require_valid_command command
         say help_formatter.render_command(command)
       end
+    end
+
+    def run_help_group(name)
+      UI.enable_paging if program(:help_paging)
+      group = group(name)
+      say help_formatter.render_group(group)
     end
 
     ##

--- a/lib/commander/runner.rb
+++ b/lib/commander/runner.rb
@@ -264,7 +264,7 @@ module Commander
     # essentially the same as using the --help switch.
     def run_help_command(args)
       UI.enable_paging if program(:help_paging)
-      @help_commands = @commands.reject { |_, v| v.hidden(false) }.to_h
+      @help_commands = @commands.reject { |_, v| v.hidden(false) }.to_h.merge(@groups)
       if args.empty? || args[0] == :error
         @help_options = []
         old_wrap = $terminal.wrap_at

--- a/lib/commander/runner.rb
+++ b/lib/commander/runner.rb
@@ -9,9 +9,13 @@ module Commander
     class InvalidCommandError < CommandError; end
 
     ##
-    # Array of commands.
+    # Hash of commands.
 
     attr_reader :commands
+
+    ##
+    # Hash of groups
+    attr_reader :groups
 
     ##
     # The global Slop Options
@@ -31,7 +35,7 @@ module Commander
     attr_accessor :trace
 
     def initialize(*inputs)
-      @program, @commands, @default_command, \
+      @program, @commands, @default_command, @groups, \
         @global_slop, @aliases, @args = inputs.map(&:dup)
 
       @commands['help'] ||= Command.new('help').tap do |c|
@@ -193,7 +197,13 @@ module Commander
     # Returns array of valid command names found within _args_.
 
     def valid_command_names_from(*args)
-      commands.keys.find_all do |name|
+      expanded_groups = groups.map do |g_name, g_obj|
+        g_obj.commands.map do |c_name, c_obj|
+          [g_name, c_name].join(' ')
+        end
+      end.flatten
+
+      x = (commands.keys + expanded_groups).find_all do |name|
         name if flagless_args_string =~ /^#{name}(?![[:graph:]])/
       end
     end


### PR DESCRIPTION
This PR introduces the ability for apps using Commander to define command groups/subcommands.

# Overview

The syntax for groups is similar to how one would define a command. A group is given a name, a syntax string, and optionally a summary/description. Groups are displayed at the top-level help dialog alongside ungrouped commands (grouped commands are no longer shown in the top-level help dialog). Each group has its own help dialog describing the subcommands within that group, which is shown when the user enters the group name without specifying a subcommand.

# In-practise

The following block will define:
- A group named `files`; with:
  - A summary
  - A description
  - Two subcommands
- An ungrouped command named set-default

```ruby
group :files do |g|
  g.summary = 'Perform file operations'
  g.syntax = 'files SUBCOMMAND'

  g.command :list do |c|
    c.description = 'List files in the specified directory'
    c.syntax = "files list"
    c.action ListCommand
  end

  g.command :delete do |c|
    c.description = 'Delete specified file'
    c.syntax = "files delete"
    c.action DeleteCommand
    c.slop.bool '-r', '--recursive', 'Delete a directory and all of its contents'
  end
end

command 'set-default' do |c|
  c.syntax = 'set-default'
  c.description = 'Set or view the default directory'
  c.action SetDefaultCommand
end
```

The default `help` dialog for the above would resemble the following:

```
  NAME:

    program_name

  DESCRIPTION:

    program_description

  COMMANDS:
	
    files       Perform file operations		
    help        Display global or [command] help documentation		
    set-default Set or view the default directory	

  GLOBAL OPTIONS:
	
    -h, --help
        Display help documentation
	
    --version
        Display version information
```

With the `help` dialog for `files` resembling the following:

```
 SYNOPSIS:

    files SUBCOMMAND

  DESCRIPTION:

    Perform file operations

  SUBCOMMANDS:

    delete Delete the specified file
    list   List files in the specified directory
```

# Future enhancements

Currently, we only allow single-level groups; as in, a group can only contain subcommands. In the future, it may be useful to implement group nesting.